### PR TITLE
Output - Remove extraneous middle of sentence

### DIFF
--- a/manuscript/01.Experiment Driven Change.md
+++ b/manuscript/01.Experiment Driven Change.md
@@ -31,7 +31,7 @@ The focus of a Retrospective is not to fix all our problems overnight; the only 
 
 ## Output
 
-Here is a very simple model I use during Retrospectives, and many other discussions, to attempt to arrive at usable experiments.
+Here is a very simple model I use to attempt to arrive at usable experiments.
 
 ![Experiment Output](images/experiment-driven-change.jpg)
 


### PR DESCRIPTION
I feel like _"during Retrospectives, and many other discussions, "_ complicates without adding value.
