### PR TITLE
:fire: remove "in the past" for simplicity

### DIFF
--- a/manuscript/06.Tasty Timeboxes.md
+++ b/manuscript/06.Tasty Timeboxes.md
@@ -1,6 +1,6 @@
 # Tasty Timeboxes
 
-Oftentimes you find a reason you want to refer to specific sprints or iterations. Maybe you want to communicate to stakeholders when in the past something was released or built, maybe you want to remind the team of a specific situation ("remember how awesome Sprint X was?!?"), or for many other reasons.
+Oftentimes you find a reason you want to refer to specific sprints or iterations. Maybe you want to communicate to stakeholders when something was released or built, maybe you want to remind the team of a specific situation ("remember how awesome Sprint X was?!?"), or for many other reasons.
 
 People solve this in a variety of ways, the simplest being a numbering convention of some kind, some people name them after the goals, and some use a naming convention of some kind. But I like to take it one step further with a tool I call, Tasty Timeboxes!
 


### PR DESCRIPTION
Tense already conveyed, no need to be over specific and pay with readability.
