### PR TITLE
Add comma & fix typo: "the" -> "to"

### DIFF
--- a/manuscript/15.Visualised Flow.md
+++ b/manuscript/15.Visualised Flow.md
@@ -55,7 +55,7 @@ If you are not yet at this stage, you need to also visualise what happens after 
 
 ![The Outflow](images/visualised-flow-4.png)
 
-In this example we have a “Deployment Test” phase, and then we hand over the the deployment team so we have a waiting area for that. This helps a lot in this example because people start to ask questions like:
+In this example we have a “Deployment Test” phase, and then we hand over to the deployment team so we have a waiting area for that. This helps a lot in this example because people start to ask questions like:
 
 C> *"Why are there so many items in awaiting deployment?"*
 


### PR DESCRIPTION
Why the comma? See: http://www.grammar-monster.com/lessons/commas_after_a_sentence_introduction.htm
